### PR TITLE
Fix How a File is Read

### DIFF
--- a/src/main/kotlin/com/veryfi/kotlin/ClientImpl.kt
+++ b/src/main/kotlin/com/veryfi/kotlin/ClientImpl.kt
@@ -289,11 +289,11 @@ class ClientImpl(
             categoriesLocal = LIST_CATEGORIES
         }
         val fileName = filePath.replace("^.*[/\\\\]".toRegex(), "")
-        val fileStream = ClassLoader.getSystemResourceAsStream(filePath)
+        val file = File(filePath)
         var base64EncodedString: String? = ""
         try {
-            if (fileStream != null) {
-                base64EncodedString = Base64.getEncoder().encodeToString(fileStream.readAllBytes())
+            if (file.exists() && file.canRead()) {
+                base64EncodedString = Base64.getEncoder().encodeToString(file.readBytes())
             }
         } catch (e: IOException) {
             logger.severe(e.message)


### PR DESCRIPTION
fixes veryfi/veryfi-kotlin#7

Files are no longer required to exist in the resources folder to be read properly. This fix should allow the reading of files from anywhere.