### PR TITLE
PLAT-8100: request() and requestAsync() should always return a valid JSON

### DIFF
--- a/src/main/kotlin/com/veryfi/kotlin/Client.kt
+++ b/src/main/kotlin/com/veryfi/kotlin/Client.kt
@@ -86,14 +86,18 @@ class Client(
         val request = getHttpRequest(httpVerb, endpointName, requestArguments, hasFiles)
         return try {
             val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+            val body = response.body()
+            if (!isValidJson(body)) {
+                return buildInvalidResponseErrorJson(response.statusCode(), body)
+            }
             if (response.headers() != null) {
                 val traceId = response.headers().firstValue("x-veryfi-trace-id")
                 if (traceId.isPresent) {
                     logger.info("x-veryfi-trace-id: ${traceId.get()}")
-                    return addTraceIdToResponse(response.body(), traceId.get())
+                    return addTraceIdToResponse(body, traceId.get())
                 }
             }
-            response.body()
+            body
         } catch (e: Exception) {
             logger.severe(e.message)
             val message = e.message ?: "Unknown error"
@@ -121,6 +125,10 @@ class Client(
         val request = getHttpRequest(httpVerb, endpointName, requestArguments, false)
         return httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
             .thenApply { obj: HttpResponse<String> ->
+                val body = obj.body()
+                if (!isValidJson(body)) {
+                    return@thenApply buildInvalidResponseErrorJson(obj.statusCode(), body)
+                }
                 var traceId: String? = null
                 if (obj.headers() != null) {
                     val traceIdHeader = obj.headers().firstValue("x-veryfi-trace-id")
@@ -129,7 +137,7 @@ class Client(
                         logger.info("x-veryfi-trace-id: $traceId")
                     }
                 }
-                addTraceIdToResponse(obj.body(), traceId)
+                addTraceIdToResponse(body, traceId)
             }
     }
 
@@ -253,6 +261,34 @@ class Client(
 
     fun setHttpClient(httpClient: HttpClient) {
         this.httpClient = httpClient
+    }
+
+    /**
+     * Returns true if the string is valid JSON object.
+     */
+    private fun isValidJson(s: String): Boolean {
+        if (s.isBlank()) return false
+        return try {
+            JSONObject(s)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Builds a JSON error response for invalid (non-JSON) HTTP response body.
+     * @param statusCode HTTP status code
+     * @param rawResponse Raw response body
+     */
+    private fun buildInvalidResponseErrorJson(statusCode: Int, rawResponse: String): String {
+        return JSONObject().apply {
+            put("details", org.json.JSONArray().apply {
+                put(JSONObject().apply { put("response", rawResponse) })
+            })
+            put("error", "Status code $statusCode")
+            put("status", "fail")
+        }.toString()
     }
 
     /**

--- a/src/test/kotlin/com/veryfi/kotlin/ClientTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/ClientTest.kt
@@ -1,7 +1,19 @@
 package com.veryfi.kotlin
 
 import com.veryfi.kotlin.VeryfiClientFactory.createClient
+import com.veryfi.kotlin.documents.processDocument
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.springframework.boot.test.context.SpringBootTest
+import java.io.IOException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
 
 @SpringBootTest
 class ClientTest {
@@ -11,4 +23,24 @@ class ClientTest {
     var client = createClient(clientId, username, apiKey) as Client
     var mockResponses = true // Change to “false” if you want to test your personal credential
     val interruptedExceptionJsonResponse = "{\"details\":[{\"reason\":\"java.lang.InterruptedException\"}],\"error\":\"Unknown error\",\"status\":\"fail\"}"
+    val badGatewayResponse = "<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>cloudflare</center></body></html>"
+
+    @Test
+    @Throws(IOException::class, InterruptedException::class)
+    fun invalidJsonResponseTest() {
+        if (mockResponses) {
+            val httpClient = mock(HttpClient::class.java)
+            client.setHttpClient(httpClient)
+            val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
+            `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
+            `when`(httpResponse.statusCode()).thenReturn(502)
+            `when`(httpResponse.body()).thenReturn(badGatewayResponse)
+        }
+        val path = ClassLoader.getSystemResource("receipt.jpg").path
+        val jsonResponse = client.processDocument(path, listOf(), false, null)
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("fail", document.getString("status"))
+        Assertions.assertEquals("Status code 502", document.getString("error"))
+    }
+
 }

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteAnyDocumentTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteAnyDocumentTest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.anydocuments.deleteAnyDocument
 import com.veryfi.kotlin.anydocuments.deleteAnyDocumentAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteAnyDocumentTest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteAnyDocument(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteAnyDocumentTest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteAnyDocumentAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 }

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteBankStatementTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteBankStatementTest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.bankstatements.deleteBankStatement
 import com.veryfi.kotlin.bankstatements.deleteBankStatementAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteBankStatementTest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteBankStatement(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteBankStatementTest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteBankStatementAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteBusinessCardTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteBusinessCardTest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.businessCards.deleteBusinessCard
 import com.veryfi.kotlin.businessCards.deleteBusinessCardAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteBusinessCardTest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteBusinessCard(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteBusinessCardTest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteBusinessCardAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteCheckTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteCheckTest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.checks.deleteCheck
 import com.veryfi.kotlin.checks.deleteCheckAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteCheckTest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteCheck(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteCheckTest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteCheckAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteContractTest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteContractTest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.contracts.deleteContract
 import com.veryfi.kotlin.contracts.deleteContractAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteContractTest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteContract(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteContractTest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteContractAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteW2Test.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteW2Test.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.w2s.deleteW2
 import com.veryfi.kotlin.w2s.deleteW2Async
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteW2Test : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteW2(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteW2Test : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteW2Async(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteW8BenETest.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteW8BenETest.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.w8bene.deleteW8BenE
 import com.veryfi.kotlin.w8bene.deleteW8BenEAsync
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteW8BenETest : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteW8BenE(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteW8BenETest : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteW8BenEAsync(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 

--- a/src/test/kotlin/com/veryfi/kotlin/DeleteW9Test.kt
+++ b/src/test/kotlin/com/veryfi/kotlin/DeleteW9Test.kt
@@ -2,6 +2,7 @@ package com.veryfi.kotlin;
 
 import com.veryfi.kotlin.w9s.deleteW9
 import com.veryfi.kotlin.w9s.deleteW9Async
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -30,10 +31,11 @@ class DeleteW9Test : ClientTest() {
             val httpResponse: HttpResponse<String> = mock(HttpResponse::class.java) as HttpResponse<String>
             `when`(httpClient.send(any(HttpRequest::class.java), any<BodyHandler<String>>())).thenReturn(httpResponse)
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponse = client.deleteW9(documentId)
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
     @Test
@@ -49,11 +51,12 @@ class DeleteW9Test : ClientTest() {
                 jsonResponseFuture
             )
             `when`(httpResponse.statusCode()).thenReturn(200)
-            `when`(httpResponse.body()).thenReturn("")
+            `when`(httpResponse.body()).thenReturn("{\"status\": \"ok\", \"message\": \"Document has been deleted\"}")
         }
         val jsonResponseFuture = client.deleteW9Async(documentId)
         val jsonResponse = jsonResponseFuture.get()
-        Assertions.assertTrue(jsonResponse.isEmpty())
+        val document = JSONObject(jsonResponse)
+        Assertions.assertEquals("ok", document.getString("status"))
     }
 
 } 


### PR DESCRIPTION
- All the requests will return a valid JSON, not only on exceptions.
- Tests updated